### PR TITLE
fix: better handling of notification fallback and fat jar packaging, …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,26 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.5.3</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>dd2480.ciserver.App</mainClass>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>3.6.3</version>
         <configuration>


### PR DESCRIPTION
…closes #45

- Server no longer crashes when GITHUB_TOKEN is missing
- Added maven-shade-plugin to bundle org.json into the jar
- Print full build log to server console after each CI run