### PR TITLE
fix: fix unit test not assert the right exception in webhook payload

### DIFF
--- a/src/main/java/dd2480/ciserver/WebhookPayload.java
+++ b/src/main/java/dd2480/ciserver/WebhookPayload.java
@@ -38,7 +38,7 @@ public class WebhookPayload {
 
         if (!json.has("ref") || !json.has("after")) 
         {
-        throw new IllegalArgumentException(
+        throw new org.json.JSONException(
             "Invalid push event payload - missing required fields"
         );
         }


### PR DESCRIPTION
Changed the exception being thrown to org.json.JSONException in the webhook payload constructor.

Closes #80